### PR TITLE
Don't require an explicit Endpoint step

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Basic Usage Example
 
     from woma.router import Router
     router = Router()
-    router.add('/hello/{name}', hello_endpoint)
+    router.map_endpoint('/hello/{name}', hello_endpoint)
 
 To route specific HTTP methods, specify them as kwargs:
 

--- a/README.rst
+++ b/README.rst
@@ -49,13 +49,13 @@ Basic Usage Example
 
     from woma.router import Router
     router = Router()
-    router.map('/hello/{name}', hello_controller)
+    router.add('/hello/{name}', hello_controller)
 
 To route specific HTTP methods, specify them as kwargs:
 
 .. code:: python
 
-    router.map('/articles/{article_id}',
+    router.add('/articles/{article_id}',
         get=show_article, patch=update_article, delete=delete_article)
 
 Deploying

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,6 @@ A Woma project is composed of these layers:
 
 - Actions: core business logic
 - Controllers: map request/response logic to actions
-- `Endpoints <woma/endpoints.py>`_: map HTTP methods to controllers
 - `Router <woma/router.py>`_: map URLs to endpoints
 
 These layers are conceptual. You are free to organize your code however you
@@ -44,29 +43,20 @@ Basic Usage Example
         return response
 
     # -------------------------------------------------------------------------
-    # Endpoints:
-    # The endpoint wraps your controller in a full wsgi app
-    # (something that can accept environ/start_response)
-    # -------------------------------------------------------------------------
-    
-    from woma.endpoints import Endpoint
-    hello_endpoint = Endpoint(hello_controller)
-
-    # -------------------------------------------------------------------------
     # Router:
     # The router is a wsgi app that maps paths to other wsgi apps.
     # -------------------------------------------------------------------------
 
     from woma.router import Router
     router = Router()
-    router.map_endpoint('/hello/{name}', hello_endpoint)
+    router.map_controllers('/hello/{name}', hello_controller)
 
 To route specific HTTP methods, specify them as kwargs:
 
 .. code:: python
 
-    article_endpoint = Endpoint(
-        get=get_article, put=replace_article, delete=delete_article)
+    router.map_controllers('/articles/{article_id}',
+        get=show_article, patch=update_article, delete=delete_article)
 
 Deploying
 ---------

--- a/README.rst
+++ b/README.rst
@@ -49,13 +49,13 @@ Basic Usage Example
 
     from woma.router import Router
     router = Router()
-    router.map_controllers('/hello/{name}', hello_controller)
+    router.map('/hello/{name}', hello_controller)
 
 To route specific HTTP methods, specify them as kwargs:
 
 .. code:: python
 
-    router.map_controllers('/articles/{article_id}',
+    router.map('/articles/{article_id}',
         get=show_article, patch=update_article, delete=delete_article)
 
 Deploying

--- a/examples/helloworld/app.py
+++ b/examples/helloworld/app.py
@@ -24,5 +24,5 @@ hello_controller = GreetingController(say_hello)
 goodbye_controller = GreetingController(say_goodbye)
 
 router = Router()
-router.map_controllers('/hello/{name}', hello_controller)
-router.map_controllers('/goodbye/{name}', goodbye_controller)
+router.map('/hello/{name}', hello_controller)
+router.map('/goodbye/{name}', goodbye_controller)

--- a/examples/helloworld/app.py
+++ b/examples/helloworld/app.py
@@ -24,5 +24,5 @@ hello_controller = GreetingController(say_hello)
 goodbye_controller = GreetingController(say_goodbye)
 
 router = Router()
-router.map('/hello/{name}', hello_controller)
-router.map('/goodbye/{name}', goodbye_controller)
+router.add('/hello/{name}', hello_controller)
+router.add('/goodbye/{name}', goodbye_controller)

--- a/examples/helloworld/app.py
+++ b/examples/helloworld/app.py
@@ -28,5 +28,5 @@ hello_endpoint = Endpoint(hello_controller)
 goodbye_endpoint = Endpoint(goodbye_controller)
 
 router = Router()
-router.add('/hello/{name}', hello_endpoint)
-router.add('/goodbye/{name}', goodbye_endpoint)
+router.map_endpoint('/hello/{name}', hello_endpoint)
+router.map_endpoint('/goodbye/{name}', goodbye_endpoint)

--- a/examples/helloworld/app.py
+++ b/examples/helloworld/app.py
@@ -1,4 +1,3 @@
-from woma.endpoints import Endpoint
 from woma.router import Router
 
 
@@ -24,9 +23,6 @@ class GreetingController(object):
 hello_controller = GreetingController(say_hello)
 goodbye_controller = GreetingController(say_goodbye)
 
-hello_endpoint = Endpoint(hello_controller)
-goodbye_endpoint = Endpoint(goodbye_controller)
-
 router = Router()
-router.map_endpoint('/hello/{name}', hello_endpoint)
-router.map_endpoint('/goodbye/{name}', goodbye_endpoint)
+router.map_controllers('/hello/{name}', hello_controller)
+router.map_controllers('/goodbye/{name}', goodbye_controller)

--- a/tests/endpoint_tests.py
+++ b/tests/endpoint_tests.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+
+from woma.endpoints import Endpoint
+
+
+class TestEndpointEquality(TestCase):
+    def test_equal_if_controllers_are_equal(self):
+        controller1, controller2 = object(), object()
+        endpoint1 = Endpoint(get=controller1, post=controller2)
+        endpoint2 = Endpoint(get=controller1, post=controller2)
+        self.assertEqual(endpoint1, endpoint2)
+
+    def test_not_equal_if_controllers_differ(self):
+        controller1, controller2 = object(), object()
+        endpoint1 = Endpoint(get=controller1, post=controller2)
+        endpoint2 = Endpoint(get=controller1, delete=controller2)
+        self.assertNotEqual(endpoint1, endpoint2)

--- a/tests/router_tests.py
+++ b/tests/router_tests.py
@@ -20,6 +20,15 @@ class TestRouterInit(RouterTestCase):
         verify(self.routes.setdefault).called_with(default)
 
 
+class TestRouterAdd(RouterTestCase):
+    """router.add(route)"""
+
+    def test_adds_route_to_the_routes_collection(self):
+        route = object()
+        self.router.add(route)
+        verify(self.routes.add).called_with(route)
+
+
 class TestRouterMapEndpoint(RouterTestCase):
     """router.map_endpoint(path, endpoint)"""
 

--- a/tests/router_tests.py
+++ b/tests/router_tests.py
@@ -33,11 +33,16 @@ class TestRouterMapEndpoint(RouterTestCase):
 class TestRouterMapControllers(RouterTestCase):
     """router.map_controllers(path, **controllers)"""
 
+    @property
+    def subject(self):
+        # The subject of this test, abstracted to test shared behavior
+        return self.router.map_controllers
+
     def test_adds_an_endpoint_to_router_for_the_given_controllers(self):
         controller1, controller2 = object(), object()
         expected_endpoint = Endpoint(get=controller1, post=controller2)
         expected_route = Route(path='/path', endpoint=expected_endpoint)
-        self.router.map_controllers('/path', get=controller1, post=controller2)
+        self.subject('/path', get=controller1, post=controller2)
         verify(self.routes.add).called_with(expected_route)
 
     def test_accepts_default_controller(self):
@@ -45,8 +50,17 @@ class TestRouterMapControllers(RouterTestCase):
         controller = object()
         expected_endpoint = Endpoint(controller)
         expected_route = Route('/the/path', endpoint=expected_endpoint)
-        self.router.map_controllers('/the/path', controller)
+        self.subject('/the/path', controller)
         verify(self.routes.add).called_with(expected_route)
+
+
+class TestRouterMap(TestRouterMapControllers):
+    """router.map aliases router.map_controllers"""
+
+    @property
+    def subject(self):
+        # The subject of this test, abstracted to test shared behavior
+        return self.router.map
 
 
 class TestRouterSetDefault(RouterTestCase):

--- a/tests/router_tests.py
+++ b/tests/router_tests.py
@@ -20,13 +20,13 @@ class TestRouterInit(RouterTestCase):
         verify(self.routes.setdefault).called_with(default)
 
 
-class TestRouterAdd(RouterTestCase):
-    """router.add(path, endpoint)"""
+class TestRouterMapEndpoint(RouterTestCase):
+    """router.map_endpoint(path, endpoint)"""
 
     def test_adds_route_to_routes(self):
         endpoint = Stub('endpoint')
         expected_route = Route(path='/path', endpoint=endpoint)
-        self.router.add('/path', endpoint)
+        self.router.map_endpoint('/path', endpoint)
         verify(self.routes.add).called_with(expected_route)
 
 

--- a/tests/router_tests.py
+++ b/tests/router_tests.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from tdubs import calling, verify, Mock, Stub
 
 from woma.router import Router, Route
-from woma.endpoints import not_found
+from woma.endpoints import Endpoint, not_found
 
 
 class RouterTestCase(TestCase):
@@ -27,6 +27,25 @@ class TestRouterMapEndpoint(RouterTestCase):
         endpoint = Stub('endpoint')
         expected_route = Route(path='/path', endpoint=endpoint)
         self.router.map_endpoint('/path', endpoint)
+        verify(self.routes.add).called_with(expected_route)
+
+
+class TestRouterMapControllers(RouterTestCase):
+    """router.map_controllers(path, **controllers)"""
+
+    def test_adds_an_endpoint_to_router_for_the_given_controllers(self):
+        controller1, controller2 = object(), object()
+        expected_endpoint = Endpoint(get=controller1, post=controller2)
+        expected_route = Route(path='/path', endpoint=expected_endpoint)
+        self.router.map_controllers('/path', get=controller1, post=controller2)
+        verify(self.routes.add).called_with(expected_route)
+
+    def test_accepts_default_controller(self):
+        """can also be called like: router.map_controllers(path, controller)"""
+        controller = object()
+        expected_endpoint = Endpoint(controller)
+        expected_route = Route('/the/path', endpoint=expected_endpoint)
+        self.router.map_controllers('/the/path', controller)
         verify(self.routes.add).called_with(expected_route)
 
 

--- a/tests/router_tests.py
+++ b/tests/router_tests.py
@@ -20,12 +20,12 @@ class TestRouterInit(RouterTestCase):
         verify(self.routes.setdefault).called_with(default)
 
 
-class TestRouterAdd(RouterTestCase):
-    """router.add(route)"""
+class TestRouterAddRoute(RouterTestCase):
+    """router.add_route(route)"""
 
     def test_adds_route_to_the_routes_collection(self):
         route = object()
-        self.router.add(route)
+        self.router.add_route(route)
         verify(self.routes.add).called_with(route)
 
 
@@ -64,12 +64,12 @@ class TestRouterMapControllers(RouterTestCase):
 
 
 class TestRouterMap(TestRouterMapControllers):
-    """router.map aliases router.map_controllers"""
+    """router.add aliases router.map_controllers"""
 
     @property
     def subject(self):
         # The subject of this test, abstracted to test shared behavior
-        return self.router.map
+        return self.router.add
 
 
 class TestRouterSetDefault(RouterTestCase):

--- a/woma/endpoints.py
+++ b/woma/endpoints.py
@@ -42,7 +42,7 @@ class Endpoint(object):
 
     >>> from woma.router import Router
     >>> router = Router()
-    >>> router.add('/widgets', widget_collection)
+    >>> router.map_endpoint('/widgets', widget_collection)
     >>> Client(router).get('/widgets').text
     'widget 1 widget 2'
 

--- a/woma/endpoints.py
+++ b/woma/endpoints.py
@@ -68,5 +68,8 @@ class Endpoint(object):
         response = controller(request, response)
         return response(environ, start_response)
 
+    def __eq__(self, other):
+        return self.controllers == other.controllers
+
 
 not_found = Endpoint(not_found)

--- a/woma/router.py
+++ b/woma/router.py
@@ -19,6 +19,11 @@ class Router(object):
         self.routes = routes or Routes()
         self.setdefault(not_found)
 
+    @property
+    def map(self):
+        """router.map is an alias for router.map_controllers"""
+        return self.map_controllers
+
     def map_endpoint(self, path, endpoint):
         """Map the path to the given endpoint.
 

--- a/woma/router.py
+++ b/woma/router.py
@@ -24,6 +24,21 @@ class Router(object):
         """router.map is an alias for router.map_controllers"""
         return self.map_controllers
 
+    def add(self, route):
+        """Add a predefined route to the router.
+
+        For example:
+
+            route = Route('/path', endpoint)
+            router.add(route)
+
+        This is a low-level method. Usually, you don't need to define route
+        objects yourself, and can use .map, .map_controllers, or .map_endpoint
+        instead. See the documentation for those methods.
+
+        """
+        self.routes.add(route)
+
     def map_endpoint(self, path, endpoint):
         """Map the path to the given endpoint.
 
@@ -37,7 +52,7 @@ class Router(object):
 
         """
         route = Route(path, endpoint)
-        self.routes.add(route)
+        self.add(route)
 
     def map_controllers(self, path, default_controller=None, **controllers):
         """Create an endpoint for the given controllers and add it to router.

--- a/woma/router.py
+++ b/woma/router.py
@@ -18,7 +18,7 @@ class Router(object):
 
     You will usually route paths to controllers:
 
-        router.map('/path', get=my_controller, post=my_other_controller)
+        router.add('/path', get=my_controller, post=my_other_controller)
 
     All of the HTTP verbs are supported as kwargs.
 
@@ -27,7 +27,7 @@ class Router(object):
 
     Your path can contain dynamic sections:
 
-        router.map('/articles/{article_id}', get=get_article, post=add_article)
+        router.add('/articles/{article_id}', get=get_article, post=add_article)
 
     When the controller is called, the passed ``request`` object will have a
     ``kwargs`` property that holds a dict of the values passed in the dynamic
@@ -49,7 +49,7 @@ class Router(object):
 
         article_endpoint = Endpoint(get=get_article, post=add_article)
         route = Route('/articles/{article_id}', endpoint)
-        router.add(route)
+        router.add_route(route)
 
     **WSGI:**
 
@@ -67,20 +67,20 @@ class Router(object):
         self.setdefault(not_found)
 
     @property
-    def map(self):
-        """router.map is an alias for router.map_controllers"""
+    def add(self):
+        """router.add is an alias for router.map_controllers"""
         return self.map_controllers
 
-    def add(self, route):
+    def add_route(self, route):
         """Add a predefined route to the router.
 
         For example:
 
             route = Route('/path', endpoint)
-            router.add(route)
+            router.add_route(route)
 
         This is a low-level method. Usually, you don't need to define route
-        objects yourself, and can use .map, .map_controllers, or .map_endpoint
+        objects yourself, and can use .add, .map_controllers, or .map_endpoint
         instead. See the documentation for those methods.
 
         """
@@ -99,7 +99,7 @@ class Router(object):
 
         """
         route = Route(path, endpoint)
-        self.add(route)
+        self.add_route(route)
 
     def map_controllers(self, path, default_controller=None, **controllers):
         """Create an endpoint for the given controllers and add it to router.

--- a/woma/router.py
+++ b/woma/router.py
@@ -19,7 +19,7 @@ class Router(object):
         self.routes = routes or Routes()
         self.setdefault(not_found)
 
-    def add(self, path, endpoint):
+    def map_endpoint(self, path, endpoint):
         """Map the path to the given endpoint.
 
         - path: a string representing a URL path. e.g. '/articles'.

--- a/woma/router.py
+++ b/woma/router.py
@@ -3,7 +3,7 @@ import re
 from property_caching import cached_property
 from webob import Request
 
-from woma.endpoints import not_found
+from woma.endpoints import Endpoint, not_found
 from woma.exceptions import NotFound
 
 
@@ -33,6 +33,24 @@ class Router(object):
         """
         route = Route(path, endpoint)
         self.routes.add(route)
+
+    def map_controllers(self, path, default_controller=None, **controllers):
+        """Create an endpoint for the given controllers and add it to router.
+
+        Example:
+
+            router.map_controllers('/path', get=controller1, post=controller2)
+
+        is equivalent to:
+
+            endpoint = Endpoint(get=controller1, post=controller2)
+            router.map_endpoint('/path', endpoint)
+
+        See docs for Router.map_endpoint for more details.
+
+        """
+        endpoint = Endpoint(default_controller, **controllers)
+        self.map_endpoint(path, endpoint)
 
     def setdefault(self, endpoint):
         """Set the default endpoint to use for unmatched paths."""

--- a/woma/router.py
+++ b/woma/router.py
@@ -8,7 +8,54 @@ from woma.exceptions import NotFound
 
 
 class Router(object):
-    """WSGI app that can route paths to other WSGI apps (called endpoints)."""
+    """Map URL paths to handlers. Supports being used as WSGI callable.
+
+    High-level API
+    ---------------
+
+        from woma.router import Router
+        router = Router()
+
+    You will usually route paths to controllers:
+
+        router.map('/path', get=my_controller, post=my_other_controller)
+
+    All of the HTTP verbs are supported as kwargs.
+
+    Dynamic path segments
+    ----------------------
+
+    Your path can contain dynamic sections:
+
+        router.map('/articles/{article_id}', get=get_article, post=add_article)
+
+    When the controller is called, the passed ``request`` object will have a
+    ``kwargs`` property that holds a dict of the values passed in the dynamic
+    parts of the URL. For example, on requests to ``/articles/3``,
+    the incoming ``request.kwargs`` will be ``{'article_id': 3}``.
+
+    Low-level API
+    --------------
+
+    Interally, controllers are wrapped in a `woma.endpoints.Endpoint`.  If you
+    need to customize the endpoint (e.g. to add middleware), you can route
+    paths directly to endpoints yourself. The above example is equivalent to:
+
+        article_endpoint = Endpoint(get=get_article, post=add_article)
+        router.map_endpoint('/articles/{article_id}', endpoint)
+
+    If you need to get even lower-level, you can define `woma.router.Route`
+    objects yourself. The above example is equivalent to:
+
+        article_endpoint = Endpoint(get=get_article, post=add_article)
+        route = Route('/articles/{article_id}', endpoint)
+        router.add(route)
+
+    **WSGI:**
+
+    Routers are WSGI callables. See `woma.router.Route.__call__` for details.
+
+    """
 
     def __init__(self, routes=None):
         """Initialize a router, optionally with a preloaded Routes object.
@@ -78,7 +125,17 @@ class Router(object):
         self.routes.setdefault(route)
 
     def __call__(self, environ, start_response):
-        """The wsgi callable."""
+        """The wsgi callable.
+
+        When called, a route is found that matches the path in the ``environ``,
+        and ``environ`` and ``start_response`` are passed through to the
+        route's ``endpoint`` property, and the result is returned.
+
+        Dynamic path segments are added as a ``'router.kwargs'`` key to the
+        ``environ`` before passing it to the endpoint. The endpoint is the
+        thing that turns that into ``request.kwargs`` when calling controllers.
+
+        """
         request = Request(environ)
         route = self.routes.get(request.path)
         environ['router.kwargs'] = route.kwargs


### PR DESCRIPTION
Before this pull, you had to do this:

``` python
my_endpoint = Endpoint(my_controller)
router.add('/path', my_endpoint)
```

Now you can do this:

``` python
router.add('/path', my_controller)
```

and the router will wrap your controller(s) in an endpoint for you.

You can still make the endpoint step explicit like this:

``` python
my_endpoint = Endpoint(my_controller)
router.map_endpoint('/path', my_endpoint)
```

Closes #11 
